### PR TITLE
Add libbubicapture reuse documentation (EN/IT)

### DIFF
--- a/docs/libbubicapture/README.it.md
+++ b/docs/libbubicapture/README.it.md
@@ -1,0 +1,251 @@
+# libbubicapture
+
+Una piccola libreria di cattura per Haiku: elenca le webcam USB tramite il Media
+Kit e ti consegna i frame video già decodificati (e i livelli audio), senza il
+boilerplate del Media Kit.
+
+È il componente `src/webcam/` di BubiCam, impacchettato perché altre
+applicazioni possano riusarlo. BubiCam ne è un consumatore; la tua app può
+essere un altro.
+
+> Stato: questo documento descrive il contratto pubblico del componente di
+> cattura. Il codice è in `src/webcam/`. Una volta estratto come libreria a sé,
+> mantiene le stesse classi e lo stesso contratto descritto qui.
+
+---
+
+## Cosa fa per te
+
+- Trova le webcam registrate nel Media Kit (`WebcamRoster`).
+- Si connette a un device e avvia la pipeline di cattura (`WebcamDevice`).
+- Converte ogni formato in ingresso (MJPEG, YUYV, I420, NV12, NV21, UYVY, RGB) in
+  un unico formato pixel pronto all'uso e posta ogni frame al tuo `BLooper`.
+- Riporta le statistiche di cattura (FPS, frame catturati, frame persi).
+- Riporta i livelli di picco audio (sinistro/destro) per i VU meter.
+
+Cosa **non** fa: encoding, registrazione, streaming di rete o UI. Quelli sono
+compito dell'applicazione. La libreria ti dà solo frame puliti.
+
+---
+
+## Dipendenze
+
+Solo librerie di sistema Haiku — nessun pacchetto di terze parti:
+
+```
+be media tracker translation device shared jpeg
+```
+
+`media` esegue la cattura, `jpeg` (libjpeg-turbo) decodifica le webcam MJPEG.
+
+---
+
+## Il modello mentale (leggi prima questo)
+
+La libreria è **push-based** e costruita sul modello looper/messaggi di Haiku.
+Non interroghi tu i frame: dai al device un `BLooper` e la libreria **gli posta
+un `BMessage` per ogni frame**, da un thread del Media Kit.
+
+```
+  webcam (producer del Media Kit)
+        │  buffer grezzi
+        ▼
+  WebcamDevice  ──►  VideoConsumer interno  ──►  conversione di formato
+                                                        │
+                                  BMessage('frcv') + puntatore "bitmap"
+                                                        ▼
+                                            IL TUO BLooper::MessageReceived()
+```
+
+Tre fatti che ne derivano, e che devi rispettare:
+
+1. **Il tuo handler gira sul thread del looper, non su un thread di cattura.**
+   Valgono le regole standard di Haiku: blocca le finestre prima di toccare le
+   view, tieni l'handler breve.
+2. **Il `BBitmap` del frame è di proprietà della libreria ed è valido solo dentro
+   quel messaggio.** Se ti servono i pixel dopo il ritorno, **copiali**. Non fare
+   `delete` del bitmap e non conservare il puntatore.
+3. **I frame vengono scartati, non accodati, se rimani indietro.** La pipeline usa
+   3 buffer; un handler lento significa frame persi (vedi `FramesDropped()`), mai
+   crescita illimitata della memoria.
+
+---
+
+## Formato dei frame
+
+Ogni frame consegnato è un `BBitmap` in **`B_RGB32`** (ordine byte BGRA in
+memoria, 4 byte per pixel). Un solo formato, sempre — non devi mai ramificare sul
+codec in ingresso. Le dimensioni le prendi da `bitmap->Bounds()`, i pixel da
+`bitmap->Bits()` con `bitmap->BytesPerRow()`.
+
+---
+
+## Avvio rapido
+
+Un capturer minimale senza interfaccia: enumera, avvia il primo device, conta i
+frame.
+
+```cpp
+#include <Application.h>
+#include <Looper.h>
+#include <Bitmap.h>
+#include "WebcamRoster.h"
+#include "WebcamDevice.h"
+
+// La costante del messaggio frame che la libreria posta (vedi "Contratto del
+// messaggio frame").
+static const uint32 kFrameReceived = 'frcv';
+
+class CaptureLooper : public BLooper {
+public:
+    CaptureLooper() : BLooper("capture") {}
+
+    void MessageReceived(BMessage* msg) override {
+        if (msg->what == kFrameReceived) {
+            BBitmap* frame = NULL;
+            if (msg->FindPointer("bitmap", (void**)&frame) == B_OK && frame) {
+                // 'frame' è valido SOLO qui. Copialo se ti serve dopo.
+                fCount++;
+            }
+            return;
+        }
+        BLooper::MessageReceived(msg);
+    }
+
+    int32 fCount = 0;
+};
+
+int main() {
+    BApplication app("application/x-vnd.example-capture");
+
+    WebcamRoster roster;
+    roster.EnumerateDevices();
+    if (roster.CountDevices() == 0)
+        return 1;
+
+    WebcamDevice* dev = roster.DeviceAt(0);
+
+    CaptureLooper* looper = new CaptureLooper();
+    looper->Run();
+
+    dev->StartCapture(looper);   // i frame ora scorrono verso il looper
+    app.Run();                   // ... fai il tuo lavoro ...
+    dev->StopCapture();
+    return 0;
+}
+```
+
+Questa è tutta la superficie di integrazione: enumera, `StartCapture(looper)`,
+leggi i frame in `MessageReceived`, `StopCapture()`.
+
+---
+
+## Riferimento API
+
+### `WebcamRoster` — trovare i device
+
+`WebcamRoster` è un `BHandler`. L'enumerazione funziona da sola; le notifiche di
+hot-plug richiedono di aggiungerlo a un `BLooper` in esecuzione.
+
+| Metodo | Scopo |
+|---|---|
+| `status_t EnumerateDevices()` | Scansiona il Media Kit per le webcam. Chiamalo all'avvio, o dopo un evento di hot-plug. |
+| `int32 CountDevices()` | Numero di webcam trovate. |
+| `WebcamDevice* DeviceAt(int32 i)` | Device per indice. Di proprietà del roster — non fare delete. |
+| `WebcamDevice* DeviceByName(const char* name)` | Device per nome, oppure `NULL`. |
+| `status_t StartWatching()` / `void StopWatching()` | Abilita/disabilita le notifiche di hot-plug. |
+
+Quando i device cambiano, il roster posta `MSG_DEVICES_CHANGED` (`'dvch'`) al
+looper a cui è collegato. Ri-esegui `EnumerateDevices()` e aggiorna la tua lista.
+
+### `WebcamDevice` — catturare da una webcam
+
+Controllo della cattura:
+
+| Metodo | Scopo |
+|---|---|
+| `status_t StartCapture(BLooper* target)` | Connette la pipeline e inizia a postare i frame a `target`. |
+| `void StopCapture()` | Ferma e disconnette. Sicuro da chiamare da qualsiasi thread. |
+| `bool IsCapturing()` | Se la cattura è in corso. |
+
+Selezione del formato (chiamare **prima** di `StartCapture`):
+
+| Metodo | Scopo |
+|---|---|
+| `const BObjectList<VideoFormat>& SupportedFormats()` | Risoluzioni/frame rate dichiarati dal device. |
+| `void SetRequestedFormat(const VideoFormat&)` | Richiede una risoluzione/rate specifica. Il driver può negoziare qualcosa di vicino. |
+| `VideoFormat CurrentFormat()` | Il formato negoziato. Verificalo dopo i primi frame. |
+
+Sorgente audio (chiamare **prima** di `StartCapture`):
+
+| Metodo | Scopo |
+|---|---|
+| `bool SupportsAudio()` | Se la webcam espone un microfono. |
+| `void SetAudioNodeID(int32 id)` | `-1` = auto, `0` = nessun audio, `>0` = un node id specifico del Media Kit. |
+
+Statistiche (interrogabili in qualsiasi momento durante la cattura):
+
+| Metodo | Scopo |
+|---|---|
+| `uint32 FramesCaptured()` | Frame consegnati dall'avvio. |
+| `uint32 FramesDropped()` | Frame persi perché il consumatore è rimasto indietro. |
+| `float CurrentFPS()` | Frame rate corrente (media mobile). |
+
+Identificazione (USB / driver), utile per UI e diagnostica:
+`Name()`, `VendorID()`, `ProductID()`, `ProductName()`, `SerialNumber()`,
+`DriverName()`, `DriverVersion()`, e `GetUSBInfo()` / `GetDriverInfo()` per le
+struct complete.
+
+### Contratto del messaggio frame
+
+`StartCapture` posta, per ogni frame, al tuo looper:
+
+- `what`: `'frcv'` (`MSG_FRAME_RECEIVED`)
+- campo `"bitmap"`: un `BBitmap*` (`FindPointer`), `B_RGB32`, **in prestito** —
+  valido solo durante il messaggio, di proprietà della libreria.
+
+Messaggi di livello audio (quando l'audio è attivo):
+
+- `what`: `'audl'` (`MSG_AUDIO_LEVEL`)
+- campi `"left"` / `"right"`: livelli di picco `float` in `0.0 .. 1.0`.
+
+> Nota: queste costanti `what` sono attualmente fisse nella libreria. Se incorpori
+> i sorgenti e ti servono valori diversi, cambiali dove `WebcamDevice` costruisce
+> i suoi consumer (`MSG_FRAME_RECEIVED` / `MSG_AUDIO_LEVEL`). Renderli parametri
+> di `StartCapture` è un miglioramento API pianificato.
+
+---
+
+## Threading e ownership — le regole che fanno male
+
+- **I bitmap sono in prestito.** Validi solo dentro il messaggio `'frcv'`. Copia
+  per conservarli. Mai `delete`.
+- **I device sono di proprietà del roster.** Non fare delete di `WebcamDevice*`;
+  tieni vivo il `WebcamRoster` finché usi i suoi device.
+- **`StopCapture()` è sincrono e thread-safe.** Dopo il ritorno, nessun altro
+  messaggio frame verrà postato per quel device.
+- **Un looper, un thread di handler.** Il tuo handler dei frame non deve
+  bloccare. Sposta encoding/IO su un thread tuo; la libreria continua a catturare
+  e semplicemente scarta i frame che non riesci a smaltire.
+
+---
+
+## Compilazione
+
+Le classi sono C++ semplice con il Media Kit di Haiku. Per usarle oggi, aggiungi
+i sorgenti al tuo build e linka le librerie di sistema:
+
+```
+SRCS  += WebcamRoster.cpp WebcamDevice.cpp VideoConsumer.cpp \
+         AudioConsumer.cpp USBVideoParser.cpp
+LIBS  += be media tracker translation device shared jpeg
+```
+
+(Quando sarà impacchettata come libreria shared/static, linka `libbubicapture` e
+aggiungi i suoi header all'include path. Il contratto qui sopra non cambia.)
+
+---
+
+## Licenza
+
+MIT, come BubiCam. Vedi `LICENSE`.

--- a/docs/libbubicapture/README.it.md
+++ b/docs/libbubicapture/README.it.md
@@ -164,9 +164,14 @@ Controllo della cattura:
 
 | Metodo | Scopo |
 |---|---|
-| `status_t StartCapture(BLooper* target)` | Connette la pipeline e inizia a postare i frame a `target`. |
+| `status_t StartCapture(BLooper* target, uint32 frameMessage = MSG_WEBCAM_FRAME, uint32 audioLevelMessage = MSG_WEBCAM_AUDIO_LEVEL)` | Connette la pipeline e inizia a postare i frame a `target`. Passa i tuoi `what` per integrarti con un protocollo di messaggi tuo; i default restano `'frcv'`/`'audl'`. |
 | `void StopCapture()` | Ferma e disconnette. Sicuro da chiamare da qualsiasi thread. |
 | `bool IsCapturing()` | Se la cattura è in corso. |
+
+Per catturare i campioni audio (non solo i livelli) — per registrazione o
+encoding — passa un `AudioSink` all'`AudioConsumer` del device:
+`device->GetAudioConsumer()->SetAudioSink(mioSink)`. Il sink riceve il PCM
+grezzo direttamente dal thread audio (vedi `AudioSink.h`).
 
 Selezione del formato (chiamare **prima** di `StartCapture`):
 
@@ -206,13 +211,13 @@ struct complete.
 
 Messaggi di livello audio (quando l'audio è attivo):
 
-- `what`: `'audl'` (`MSG_AUDIO_LEVEL`)
+- `what`: `'audl'` (`MSG_WEBCAM_AUDIO_LEVEL`)
 - campi `"left"` / `"right"`: livelli di picco `float` in `0.0 .. 1.0`.
 
-> Nota: queste costanti `what` sono attualmente fisse nella libreria. Se incorpori
-> i sorgenti e ti servono valori diversi, cambiali dove `WebcamDevice` costruisce
-> i suoi consumer (`MSG_FRAME_RECEIVED` / `MSG_AUDIO_LEVEL`). Renderli parametri
-> di `StartCapture` è un miglioramento API pianificato.
+> I default sono `MSG_WEBCAM_FRAME` (`'frcv'`) e `MSG_WEBCAM_AUDIO_LEVEL`
+> (`'audl'`), definiti in `WebcamDevice.h` e di proprietà della libreria.
+> Sovrascrivili per-cattura con i parametri di `StartCapture` qui sopra — senza
+> toccare i sorgenti della libreria.
 
 ---
 

--- a/docs/libbubicapture/README.it.md
+++ b/docs/libbubicapture/README.it.md
@@ -169,9 +169,8 @@ Controllo della cattura:
 | `bool IsCapturing()` | Se la cattura è in corso. |
 
 Per catturare i campioni audio (non solo i livelli) — per registrazione o
-encoding — passa un `AudioSink` all'`AudioConsumer` del device:
-`device->GetAudioConsumer()->SetAudioSink(mioSink)`. Il sink riceve il PCM
-grezzo direttamente dal thread audio (vedi `AudioSink.h`).
+encoding — passa un `AudioSink` al device: `device->SetAudioSink(mioSink)`. Il
+sink riceve il PCM grezzo direttamente dal thread audio (vedi `AudioSink.h`).
 
 Selezione del formato (chiamare **prima** di `StartCapture`):
 

--- a/docs/libbubicapture/README.md
+++ b/docs/libbubicapture/README.md
@@ -161,9 +161,14 @@ Capture control:
 
 | Method | Purpose |
 |---|---|
-| `status_t StartCapture(BLooper* target)` | Connect the pipeline and start posting frames to `target`. |
+| `status_t StartCapture(BLooper* target, uint32 frameMessage = MSG_WEBCAM_FRAME, uint32 audioLevelMessage = MSG_WEBCAM_AUDIO_LEVEL)` | Connect the pipeline and start posting frames to `target`. Pass your own `what` codes to integrate with a custom message protocol; the defaults keep `'frcv'`/`'audl'`. |
 | `void StopCapture()` | Stop and disconnect. Safe to call from any thread. |
 | `bool IsCapturing()` | Whether capture is running. |
+
+To capture audio samples (not just levels) — for recording or encoding — give
+the device's `AudioConsumer` an `AudioSink`:
+`device->GetAudioConsumer()->SetAudioSink(mySink)`. The sink receives raw PCM
+directly from the audio thread (see `AudioSink.h`).
 
 Format selection (call **before** `StartCapture`):
 
@@ -203,13 +208,13 @@ full structs.
 
 Audio level messages (when audio is active):
 
-- `what`: `'audl'` (`MSG_AUDIO_LEVEL`)
+- `what`: `'audl'` (`MSG_WEBCAM_AUDIO_LEVEL`)
 - fields `"left"` / `"right"`: `float` peak levels in `0.0 .. 1.0`.
 
-> Note: these `what` constants are currently fixed by the library. If you embed
-> the source and need different values, change them where `WebcamDevice`
-> constructs its consumers (`MSG_FRAME_RECEIVED` / `MSG_AUDIO_LEVEL`). Making
-> them `StartCapture` parameters is a planned API improvement.
+> The defaults are `MSG_WEBCAM_FRAME` (`'frcv'`) and `MSG_WEBCAM_AUDIO_LEVEL`
+> (`'audl'`), defined in `WebcamDevice.h` and owned by the library. Override
+> them per-capture via the `StartCapture` parameters above — no need to touch
+> the library source.
 
 ---
 

--- a/docs/libbubicapture/README.md
+++ b/docs/libbubicapture/README.md
@@ -1,0 +1,248 @@
+# libbubicapture
+
+A small Haiku capture library: it enumerates USB webcams through the Media Kit
+and hands you decoded video frames (and audio levels) with no Media Kit
+boilerplate.
+
+It is the `src/webcam/` component of BubiCam, packaged so other applications can
+reuse it. BubiCam is one consumer; your app can be another.
+
+> Status: this document describes the public contract of the capture component.
+> The code lives in `src/webcam/`. When extracted as a standalone library it
+> keeps the same classes and the same contract described here.
+
+---
+
+## What it does for you
+
+- Finds webcams registered with the Media Kit (`WebcamRoster`).
+- Connects to a device and runs the capture pipeline (`WebcamDevice`).
+- Converts every input format (MJPEG, YUYV, I420, NV12, NV21, UYVY, RGB) to a
+  single, ready-to-use pixel format and posts each frame to your `BLooper`.
+- Reports capture statistics (FPS, frames captured, frames dropped).
+- Reports audio peak levels (left/right) for VU meters.
+
+What it does **not** do: encoding, recording, network streaming, or UI. Those
+are the application's job. The library only gives you clean frames.
+
+---
+
+## Dependencies
+
+Haiku system libraries only — no third-party packages:
+
+```
+be media tracker translation device shared jpeg
+```
+
+`media` does the capture, `jpeg` (libjpeg-turbo) decodes MJPEG webcams.
+
+---
+
+## The mental model (read this first)
+
+The library is **push-based** and built on Haiku's looper/messaging model. You
+do not poll for frames. You give the device a `BLooper`, and the library
+**posts a `BMessage` to it for every frame**, from a Media Kit thread.
+
+```
+  webcam (Media Kit producer)
+        │  raw buffers
+        ▼
+  WebcamDevice  ──►  internal VideoConsumer  ──►  format conversion
+                                                        │
+                                  BMessage('frcv') + "bitmap" pointer
+                                                        ▼
+                                              YOUR BLooper::MessageReceived()
+```
+
+Three facts that follow from this, and that you must respect:
+
+1. **Your handler runs on the looper thread, not a capture thread.** Standard
+   Haiku rules apply — lock windows before touching views, keep the handler
+   short.
+2. **The frame `BBitmap` is owned by the library and is only valid inside that
+   message.** If you need the pixels after returning, **copy them**. Do not
+   `delete` the bitmap and do not store the pointer.
+3. **Frames are dropped, not queued, when you fall behind.** The pipeline uses
+   3 buffers; a slow handler means dropped frames (see `FramesDropped()`), never
+   unbounded memory growth.
+
+---
+
+## Frame format
+
+Every delivered frame is a `BBitmap` in **`B_RGB32`** (BGRA byte order in
+memory, 4 bytes per pixel). One format, always — you never branch on the input
+codec. Get dimensions from `bitmap->Bounds()` and pixels from `bitmap->Bits()`
+with `bitmap->BytesPerRow()`.
+
+---
+
+## Quick start
+
+A minimal headless capturer: enumerate, start the first device, count frames.
+
+```cpp
+#include <Application.h>
+#include <Looper.h>
+#include <Bitmap.h>
+#include "WebcamRoster.h"
+#include "WebcamDevice.h"
+
+// The frame message constant the library posts (see "Frame message contract").
+static const uint32 kFrameReceived = 'frcv';
+
+class CaptureLooper : public BLooper {
+public:
+    CaptureLooper() : BLooper("capture") {}
+
+    void MessageReceived(BMessage* msg) override {
+        if (msg->what == kFrameReceived) {
+            BBitmap* frame = NULL;
+            if (msg->FindPointer("bitmap", (void**)&frame) == B_OK && frame) {
+                // 'frame' is valid ONLY here. Copy if you need to keep it.
+                fCount++;
+            }
+            return;
+        }
+        BLooper::MessageReceived(msg);
+    }
+
+    int32 fCount = 0;
+};
+
+int main() {
+    BApplication app("application/x-vnd.example-capture");
+
+    WebcamRoster roster;
+    roster.EnumerateDevices();
+    if (roster.CountDevices() == 0)
+        return 1;
+
+    WebcamDevice* dev = roster.DeviceAt(0);
+
+    CaptureLooper* looper = new CaptureLooper();
+    looper->Run();
+
+    dev->StartCapture(looper);   // frames now flow to looper
+    app.Run();                   // ... do work ...
+    dev->StopCapture();
+    return 0;
+}
+```
+
+That is the whole integration surface: enumerate, `StartCapture(looper)`, read
+frames in `MessageReceived`, `StopCapture()`.
+
+---
+
+## API reference
+
+### `WebcamRoster` — find devices
+
+`WebcamRoster` is a `BHandler`. Enumeration works standalone; live hot-plug
+notifications require adding it to a running `BLooper`.
+
+| Method | Purpose |
+|---|---|
+| `status_t EnumerateDevices()` | Scan the Media Kit for webcams. Call once at startup, or after a hot-plug event. |
+| `int32 CountDevices()` | Number of webcams found. |
+| `WebcamDevice* DeviceAt(int32 i)` | Device by index. Owned by the roster — do not delete. |
+| `WebcamDevice* DeviceByName(const char* name)` | Device by name, or `NULL`. |
+| `status_t StartWatching()` / `void StopWatching()` | Enable/disable hot-plug notifications. |
+
+When devices change, the roster posts `MSG_DEVICES_CHANGED` (`'dvch'`) to the
+looper it is attached to. Re-run `EnumerateDevices()` and refresh your list.
+
+### `WebcamDevice` — capture from one webcam
+
+Capture control:
+
+| Method | Purpose |
+|---|---|
+| `status_t StartCapture(BLooper* target)` | Connect the pipeline and start posting frames to `target`. |
+| `void StopCapture()` | Stop and disconnect. Safe to call from any thread. |
+| `bool IsCapturing()` | Whether capture is running. |
+
+Format selection (call **before** `StartCapture`):
+
+| Method | Purpose |
+|---|---|
+| `const BObjectList<VideoFormat>& SupportedFormats()` | Resolutions/frame rates the device advertises. |
+| `void SetRequestedFormat(const VideoFormat&)` | Ask for a specific resolution/rate. The driver may negotiate something close. |
+| `VideoFormat CurrentFormat()` | The negotiated format. Verify after the first frames arrive. |
+
+Audio source (call **before** `StartCapture`):
+
+| Method | Purpose |
+|---|---|
+| `bool SupportsAudio()` | Whether the webcam exposes a microphone. |
+| `void SetAudioNodeID(int32 id)` | `-1` = auto, `0` = no audio, `>0` = a specific Media Kit node id. |
+
+Statistics (poll any time during capture):
+
+| Method | Purpose |
+|---|---|
+| `uint32 FramesCaptured()` | Frames delivered since start. |
+| `uint32 FramesDropped()` | Frames dropped because the consumer fell behind. |
+| `float CurrentFPS()` | Rolling frame rate. |
+
+Identification (USB / driver), useful for UI and diagnostics:
+`Name()`, `VendorID()`, `ProductID()`, `ProductName()`, `SerialNumber()`,
+`DriverName()`, `DriverVersion()`, and `GetUSBInfo()` / `GetDriverInfo()` for the
+full structs.
+
+### Frame message contract
+
+`StartCapture` posts, for every frame, to your looper:
+
+- `what`: `'frcv'` (`MSG_FRAME_RECEIVED`)
+- field `"bitmap"`: a `BBitmap*` (`FindPointer`), `B_RGB32`, **borrowed** — valid
+  only during the message, owned by the library.
+
+Audio level messages (when audio is active):
+
+- `what`: `'audl'` (`MSG_AUDIO_LEVEL`)
+- fields `"left"` / `"right"`: `float` peak levels in `0.0 .. 1.0`.
+
+> Note: these `what` constants are currently fixed by the library. If you embed
+> the source and need different values, change them where `WebcamDevice`
+> constructs its consumers (`MSG_FRAME_RECEIVED` / `MSG_AUDIO_LEVEL`). Making
+> them `StartCapture` parameters is a planned API improvement.
+
+---
+
+## Threading and ownership — the rules that bite
+
+- **Bitmaps are borrowed.** Valid only inside the `'frcv'` message. Copy to keep.
+  Never `delete`.
+- **Devices are owned by the roster.** Do not delete `WebcamDevice*`; keep the
+  `WebcamRoster` alive for as long as you use its devices.
+- **`StopCapture()` is synchronous and thread-safe.** After it returns, no more
+  frame messages will be posted for that device.
+- **One looper, one handler thread.** Your frame handler must not block. Offload
+  encoding/IO to your own thread; the library will keep capturing and simply
+  drop frames you can't keep up with.
+
+---
+
+## Building
+
+The classes are plain C++ with the Haiku Media Kit. To use them today, add the
+sources to your build and link the system libraries:
+
+```
+SRCS  += WebcamRoster.cpp WebcamDevice.cpp VideoConsumer.cpp \
+         AudioConsumer.cpp USBVideoParser.cpp
+LIBS  += be media tracker translation device shared jpeg
+```
+
+(When packaged as a shared/static library, link `libbubicapture` instead and add
+its headers to your include path. The contract above is unchanged.)
+
+---
+
+## License
+
+MIT, same as BubiCam. See `LICENSE`.

--- a/docs/libbubicapture/README.md
+++ b/docs/libbubicapture/README.md
@@ -166,9 +166,8 @@ Capture control:
 | `bool IsCapturing()` | Whether capture is running. |
 
 To capture audio samples (not just levels) — for recording or encoding — give
-the device's `AudioConsumer` an `AudioSink`:
-`device->GetAudioConsumer()->SetAudioSink(mySink)`. The sink receives raw PCM
-directly from the audio thread (see `AudioSink.h`).
+the device an `AudioSink`: `device->SetAudioSink(mySink)`. The sink receives raw
+PCM directly from the audio thread (see `AudioSink.h`).
 
 Format selection (call **before** `StartCapture`):
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2427,8 +2427,8 @@ MainWindow::_StartRecording()
 		fprintf(stderr, "Recording: hasAudio=%d, webcam=%p, audioConsumer=%p\n",
 			hasAudio, webcam, audioConsumer);
 		if (audioConsumer != NULL) {
-			audioConsumer->SetRecorder(fRecorder);
-			fprintf(stderr, "Recording: SetRecorder(%p) on AudioConsumer\n", fRecorder);
+			audioConsumer->SetAudioSink(fRecorder);
+			fprintf(stderr, "Recording: SetAudioSink(%p) on AudioConsumer\n", fRecorder);
 		}
 	}
 
@@ -2457,7 +2457,7 @@ MainWindow::_StopRecording()
 	if (webcam != NULL) {
 		AudioConsumer* audioConsumer = webcam->GetAudioConsumer();
 		if (audioConsumer != NULL)
-			audioConsumer->ClearRecorder();
+			audioConsumer->ClearAudioSink();
 	}
 
 	uint32 frames = fRecorder->FramesRecorded();

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1283,10 +1283,8 @@ MainWindow::MessageReceived(BMessage* message)
 				if (message->FindData("audio_data", B_RAW_TYPE,
 						&data, &dataSize) == B_OK) {
 					static int32 sAudioLogCount = 0;
-					if (++sAudioLogCount <= 3) {
-						fprintf(stderr, "Recording: AddAudioBuffer %zd bytes\n",
-							(size_t)dataSize);
-					}
+					if (++sAudioLogCount <= 3)
+						LOG_DEBUG("Recording: AddAudioBuffer %zd bytes", (size_t)dataSize);
 					fRecorder->AddAudioBuffer(data, (size_t)dataSize);
 				}
 			}
@@ -2400,14 +2398,14 @@ MainWindow::_StartRecording()
 		webcam = fCurrentWebcam;
 	}
 	if (webcam != NULL && webcam->SupportsAudio()) {
-		fprintf(stderr, "Recording: StartWithAudio %.0f Hz, %d ch, %d bit\n",
+		LOG_INFO("Recording: StartWithAudio %.0f Hz, %d ch, %d bit",
 			webcam->AudioSampleRate(), (int)webcam->AudioChannels(),
 			(int)webcam->AudioBitsPerSample());
 		status = fRecorder->StartWithAudio(filePath.Path(), width, height, fps,
 			webcam->AudioSampleRate(), webcam->AudioChannels(),
 			webcam->AudioBitsPerSample());
 	} else {
-		fprintf(stderr, "Recording: Start (no audio, supportsAudio=%d, webcam=%p)\n",
+		LOG_INFO("Recording: Start (no audio, supportsAudio=%d, webcam=%p)",
 			webcam ? webcam->SupportsAudio() : -1, webcam);
 		status = fRecorder->Start(filePath.Path(), width, height, fps);
 	}
@@ -2423,13 +2421,8 @@ MainWindow::_StartRecording()
 	// Connect recorder directly to audio consumer for zero-loss recording
 	bool hasAudio = fRecorder->HasAudio();
 	if (hasAudio && webcam != NULL) {
-		AudioConsumer* audioConsumer = webcam->GetAudioConsumer();
-		fprintf(stderr, "Recording: hasAudio=%d, webcam=%p, audioConsumer=%p\n",
-			hasAudio, webcam, audioConsumer);
-		if (audioConsumer != NULL) {
-			audioConsumer->SetAudioSink(fRecorder);
-			fprintf(stderr, "Recording: SetAudioSink(%p) on AudioConsumer\n", fRecorder);
-		}
+		webcam->SetAudioSink(fRecorder);
+		LOG_DEBUG("Recording: routed audio to recorder sink %p", fRecorder);
 	}
 
 	BString statusMsg;
@@ -2454,11 +2447,8 @@ MainWindow::_StopRecording()
 		BAutolock lock(fWebcamLock);
 		webcam = fCurrentWebcam;
 	}
-	if (webcam != NULL) {
-		AudioConsumer* audioConsumer = webcam->GetAudioConsumer();
-		if (audioConsumer != NULL)
-			audioConsumer->ClearAudioSink();
-	}
+	if (webcam != NULL)
+		webcam->ClearAudioSink();
 
 	uint32 frames = fRecorder->FramesRecorded();
 	bigtime_t duration = fRecorder->Duration();

--- a/src/utils/VideoRecorder.cpp
+++ b/src/utils/VideoRecorder.cpp
@@ -239,6 +239,35 @@ VideoRecorder::AddAudioBuffer(const void* data, size_t size)
 }
 
 
+void
+VideoRecorder::WriteAudio(const void* data, size_t size,
+	const media_raw_audio_format& format)
+{
+	if (data == NULL || size == 0)
+		return;
+
+	if (format.format == media_raw_audio_format::B_AUDIO_FLOAT) {
+		// Convert 32-bit float to 16-bit PCM for AVI compatibility
+		const float* floatData = static_cast<const float*>(data);
+		size_t sampleCount = size / sizeof(float);
+		size_t pcmSize = sampleCount * sizeof(int16);
+		int16* pcmData = new int16[sampleCount];
+
+		for (size_t i = 0; i < sampleCount; i++) {
+			float sample = floatData[i];
+			if (sample > 1.0f) sample = 1.0f;
+			if (sample < -1.0f) sample = -1.0f;
+			pcmData[i] = (int16)(sample * 32767.0f);
+		}
+
+		AddAudioBuffer(pcmData, pcmSize);
+		delete[] pcmData;
+	} else {
+		AddAudioBuffer(data, size);
+	}
+}
+
+
 status_t
 VideoRecorder::Stop()
 {

--- a/src/utils/VideoRecorder.cpp
+++ b/src/utils/VideoRecorder.cpp
@@ -44,6 +44,8 @@ VideoRecorder::VideoRecorder()
 	fBitsPerSample(0),
 	fAudioChunkCount(0),
 	fTotalAudioBytes(0),
+	fAudioScratch(NULL),
+	fAudioScratchSamples(0),
 	fMoviListStart(0),
 	fMoviDataStart(0),
 	fVideoIndex(20),
@@ -56,6 +58,8 @@ VideoRecorder::~VideoRecorder()
 {
 	if (fRecording)
 		Stop();
+
+	delete[] fAudioScratch;
 }
 
 
@@ -247,21 +251,25 @@ VideoRecorder::WriteAudio(const void* data, size_t size,
 		return;
 
 	if (format.format == media_raw_audio_format::B_AUDIO_FLOAT) {
-		// Convert 32-bit float to 16-bit PCM for AVI compatibility
+		// Convert 32-bit float to 16-bit PCM for AVI compatibility, reusing a
+		// scratch buffer to avoid allocating on the real-time audio thread.
 		const float* floatData = static_cast<const float*>(data);
 		size_t sampleCount = size / sizeof(float);
-		size_t pcmSize = sampleCount * sizeof(int16);
-		int16* pcmData = new int16[sampleCount];
+
+		if (sampleCount > fAudioScratchSamples) {
+			delete[] fAudioScratch;
+			fAudioScratch = new int16[sampleCount];
+			fAudioScratchSamples = sampleCount;
+		}
 
 		for (size_t i = 0; i < sampleCount; i++) {
 			float sample = floatData[i];
 			if (sample > 1.0f) sample = 1.0f;
 			if (sample < -1.0f) sample = -1.0f;
-			pcmData[i] = (int16)(sample * 32767.0f);
+			fAudioScratch[i] = (int16)(sample * 32767.0f);
 		}
 
-		AddAudioBuffer(pcmData, pcmSize);
-		delete[] pcmData;
+		AddAudioBuffer(fAudioScratch, sampleCount * sizeof(int16));
 	} else {
 		AddAudioBuffer(data, size);
 	}

--- a/src/utils/VideoRecorder.h
+++ b/src/utils/VideoRecorder.h
@@ -82,6 +82,11 @@ private:
 	uint32				fAudioChunkCount;
 	uint32				fTotalAudioBytes;
 
+	// Reusable float->int16 conversion scratch. Avoids a heap allocation on
+	// every audio buffer: WriteAudio() runs on the real-time audio thread.
+	int16*				fAudioScratch;
+	size_t				fAudioScratchSamples;
+
 	// AVI structure tracking
 	off_t				fMoviListStart;
 	off_t				fMoviDataStart;

--- a/src/utils/VideoRecorder.h
+++ b/src/utils/VideoRecorder.h
@@ -18,6 +18,8 @@
 #include <stdio.h>
 #include <jpeglib.h>
 
+#include "AudioSink.h"
+
 
 struct AVIIndexEntry {
 	off_t		offset;
@@ -25,10 +27,10 @@ struct AVIIndexEntry {
 };
 
 
-class VideoRecorder {
+class VideoRecorder : public AudioSink {
 public:
 						VideoRecorder();
-						~VideoRecorder();
+	virtual				~VideoRecorder();
 
 	status_t			Start(const char* path, int32 width, int32 height,
 							float fps = 30.0f, int jpegQuality = 85);
@@ -39,6 +41,11 @@ public:
 	status_t			AddFrame(BBitmap* bitmap);
 	status_t			AddAudioBuffer(const void* data, size_t size);
 	status_t			Stop();
+
+	// AudioSink: accepts raw PCM from the capture library and converts it
+	// (float -> int16 when needed) before storing it in the AVI stream.
+	virtual void		WriteAudio(const void* data, size_t size,
+							const media_raw_audio_format& format);
 
 	bool				IsRecording() const { return fRecording; }
 	bool				HasAudio() const { return fHasAudio; }

--- a/src/webcam/AudioConsumer.cpp
+++ b/src/webcam/AudioConsumer.cpp
@@ -5,8 +5,6 @@
  */
 
 #include "AudioConsumer.h"
-#include "MainWindow.h"
-#include "VideoRecorder.h"
 
 #include <Autolock.h>
 #include <Buffer.h>
@@ -40,7 +38,7 @@ AudioConsumer::AudioConsumer(const char* name, BLooper* target,
 	fSmoothedRight(0.0f),
 	fBufferCount(0),
 	fLevelLogCount(0),
-	fRecorder(NULL)
+	fSink(NULL)
 {
 	fInput = media_input();
 	fFormat = media_format();
@@ -282,18 +280,18 @@ AudioConsumer::SetTarget(BLooper* target)
 
 
 void
-AudioConsumer::SetRecorder(VideoRecorder* recorder)
+AudioConsumer::SetAudioSink(AudioSink* sink)
 {
-	BAutolock lock(fRecorderLock);
-	fRecorder = recorder;
+	BAutolock lock(fSinkLock);
+	fSink = sink;
 }
 
 
 void
-AudioConsumer::ClearRecorder()
+AudioConsumer::ClearAudioSink()
 {
-	BAutolock lock(fRecorderLock);
-	fRecorder = NULL;
+	BAutolock lock(fSinkLock);
+	fSink = NULL;
 }
 
 
@@ -344,34 +342,15 @@ AudioConsumer::_HandleBuffer(BBuffer* buffer)
 	if (target == NULL)
 		return;
 
-	// Write audio directly to recorder (bypasses message loop to prevent
-	// buffer loss from queue congestion during video frame processing)
+	// Push audio directly to the sink (bypasses message loop to prevent
+	// buffer loss from queue congestion during video frame processing).
+	// Raw PCM is forwarded as-is with its format; any conversion the
+	// destination needs (e.g. float -> int16 for AVI) is the sink's job.
 	size_t dataSize = buffer->SizeUsed();
 	if (dataSize > 0) {
-		BAutolock recLock(fRecorderLock);
-		if (fRecorder != NULL) {
-			uint32 audioFormat = fFormat.u.raw_audio.format;
-
-			if (audioFormat == media_raw_audio_format::B_AUDIO_FLOAT) {
-				// Convert 32-bit float to 16-bit PCM for AVI compatibility
-				const float* floatData = static_cast<const float*>(buffer->Data());
-				size_t sampleCount = dataSize / sizeof(float);
-				size_t pcmSize = sampleCount * sizeof(int16);
-				int16* pcmData = new int16[sampleCount];
-
-				for (size_t i = 0; i < sampleCount; i++) {
-					float sample = floatData[i];
-					if (sample > 1.0f) sample = 1.0f;
-					if (sample < -1.0f) sample = -1.0f;
-					pcmData[i] = (int16)(sample * 32767.0f);
-				}
-
-				fRecorder->AddAudioBuffer(pcmData, pcmSize);
-				delete[] pcmData;
-			} else {
-				fRecorder->AddAudioBuffer(buffer->Data(), dataSize);
-			}
-		}
+		BAutolock sinkLock(fSinkLock);
+		if (fSink != NULL)
+			fSink->WriteAudio(buffer->Data(), dataSize, fFormat.u.raw_audio);
 	}
 
 	bigtime_t now = system_time();

--- a/src/webcam/AudioConsumer.cpp
+++ b/src/webcam/AudioConsumer.cpp
@@ -38,7 +38,9 @@ AudioConsumer::AudioConsumer(const char* name, BLooper* target,
 	fSmoothedRight(0.0f),
 	fBufferCount(0),
 	fLevelLogCount(0),
-	fSink(NULL)
+	fSink(NULL),
+	fSwapScratch(NULL),
+	fSwapScratchSize(0)
 {
 	fInput = media_input();
 	fFormat = media_format();
@@ -70,6 +72,8 @@ AudioConsumer::~AudioConsumer()
 			fprintf(stderr, "AudioConsumer: looper thread did not exit in time\n");
 		}
 	}
+
+	delete[] fSwapScratch;
 }
 
 
@@ -393,6 +397,18 @@ AudioConsumer::_HandleBuffer(BBuffer* buffer)
 }
 
 
+uint8*
+AudioConsumer::_SwapBuffer(size_t bytes)
+{
+	if (bytes > fSwapScratchSize) {
+		delete[] fSwapScratch;
+		fSwapScratch = new uint8[bytes];
+		fSwapScratchSize = bytes;
+	}
+	return fSwapScratch;
+}
+
+
 void
 AudioConsumer::_CalculateLevels(const void* data, size_t size,
 	float* outLeft, float* outRight)
@@ -427,15 +443,15 @@ AudioConsumer::_CalculateLevels(const void* data, size_t size,
 			// Haiku x86 is little-endian (B_MEDIA_LITTLE_ENDIAN = 2)
 			if (byteOrder == B_MEDIA_BIG_ENDIAN) {
 				// Swap bytes for each int16 sample before computing levels
-				// Work on a temporary copy to avoid modifying the buffer
-				int16* swapped = new int16[samples];
+				// Work on a reusable copy to avoid modifying the buffer
+				int16* swapped = reinterpret_cast<int16*>(
+					_SwapBuffer(samples * sizeof(int16)));
 				const uint8* raw = static_cast<const uint8*>(data);
 				for (size_t i = 0; i < samples; i++) {
 					swapped[i] = (int16)((raw[i * 2 + 1]) | (raw[i * 2] << 8));
 				}
 				_CalculateLevelsTyped(swapped, samples, channels,
 					(int16)32767, outLeft, outRight);
-				delete[] swapped;
 			} else {
 				_CalculateLevelsTyped(static_cast<const int16*>(data),
 					samples, channels, (int16)32767, outLeft, outRight);
@@ -449,7 +465,8 @@ AudioConsumer::_CalculateLevels(const void* data, size_t size,
 			uint32 byteOrder = fFormat.u.raw_audio.byte_order;
 
 			if (byteOrder == B_MEDIA_BIG_ENDIAN) {
-				int32* swapped = new int32[samples];
+				int32* swapped = reinterpret_cast<int32*>(
+					_SwapBuffer(samples * sizeof(int32)));
 				const uint8* raw = static_cast<const uint8*>(data);
 				for (size_t i = 0; i < samples; i++) {
 					size_t o = i * 4;
@@ -458,7 +475,6 @@ AudioConsumer::_CalculateLevels(const void* data, size_t size,
 				}
 				_CalculateLevelsTyped(swapped, samples, channels,
 					(int32)2147483647, outLeft, outRight);
-				delete[] swapped;
 			} else {
 				_CalculateLevelsTyped(static_cast<const int32*>(data),
 					samples, channels, (int32)2147483647, outLeft, outRight);
@@ -473,10 +489,10 @@ AudioConsumer::_CalculateLevels(const void* data, size_t size,
 			size_t frameCount = sampleCount / channels;
 
 			// Byte-swap floats if big-endian
-			float* swapped = NULL;
 			uint32 byteOrder = fFormat.u.raw_audio.byte_order;
 			if (byteOrder == B_MEDIA_BIG_ENDIAN) {
-				swapped = new float[sampleCount];
+				float* swapped = reinterpret_cast<float*>(
+					_SwapBuffer(sampleCount * sizeof(float)));
 				const uint8* raw = static_cast<const uint8*>(data);
 				for (size_t i = 0; i < sampleCount; i++) {
 					uint32 v = (uint32)((raw[i*4+3]) | (raw[i*4+2]<<8) |
@@ -511,7 +527,6 @@ AudioConsumer::_CalculateLevels(const void* data, size_t size,
 				*outRight = channels > 1 ?
 					(float)sqrt(sumRight / frameCount) : *outLeft;
 			}
-			delete[] swapped;
 			break;
 		}
 

--- a/src/webcam/AudioConsumer.h
+++ b/src/webcam/AudioConsumer.h
@@ -67,6 +67,9 @@ private:
 	void				_HandleBuffer(BBuffer* buffer);
 	void				_CalculateLevels(const void* data, size_t size,
 							float* outLeft, float* outRight);
+	// Returns a reusable buffer of at least 'bytes'. Avoids per-buffer
+	// allocation on the real-time audio thread.
+	uint8*				_SwapBuffer(size_t bytes);
 
 	template<typename T>
 	void				_CalculateLevelsTyped(const T* data, size_t samples,
@@ -93,6 +96,10 @@ private:
 	// Direct audio path (bypasses message loop)
 	AudioSink*			fSink;
 	mutable BLocker		fSinkLock;
+
+	// Reusable byte-swap scratch (big-endian sources only)
+	uint8*				fSwapScratch;
+	size_t				fSwapScratchSize;
 };
 
 #endif // AUDIO_CONSUMER_H

--- a/src/webcam/AudioConsumer.h
+++ b/src/webcam/AudioConsumer.h
@@ -12,6 +12,8 @@
 #include <Looper.h>
 #include <MediaEventLooper.h>
 
+#include "AudioSink.h"
+
 class AudioConsumer : public BMediaEventLooper, public BBufferConsumer {
 public:
 						AudioConsumer(const char* name, BLooper* target,
@@ -56,9 +58,10 @@ public:
 	// Target management (thread-safe)
 	void				SetTarget(BLooper* target);
 
-	// Direct recorder access (bypasses message loop for audio data)
-	void				SetRecorder(class VideoRecorder* recorder);
-	void				ClearRecorder();
+	// Direct audio sink (bypasses message loop for audio data).
+	// The sink receives raw PCM straight from the audio thread.
+	void				SetAudioSink(AudioSink* sink);
+	void				ClearAudioSink();
 
 private:
 	void				_HandleBuffer(BBuffer* buffer);
@@ -87,9 +90,9 @@ private:
 	int32				fBufferCount;
 	int32				fLevelLogCount;
 
-	// Direct recording path (bypasses message loop)
-	class VideoRecorder*	fRecorder;
-	mutable BLocker		fRecorderLock;
+	// Direct audio path (bypasses message loop)
+	AudioSink*			fSink;
+	mutable BLocker		fSinkLock;
 };
 
 #endif // AUDIO_CONSUMER_H

--- a/src/webcam/AudioSink.h
+++ b/src/webcam/AudioSink.h
@@ -1,0 +1,37 @@
+/*
+ * BubiCam - Webcam Driver Tester for Haiku OS
+ * Copyright (c) 2024 BubiCam Contributors
+ * MIT License
+ *
+ * AudioSink - Abstract destination for captured audio.
+ *
+ * AudioConsumer pushes every captured audio buffer to an AudioSink directly
+ * from the real-time audio thread (it bypasses the message loop to avoid
+ * buffer loss during video processing). Implement this interface to route
+ * audio anywhere - an AVI recorder, an encoder, a network stream - without
+ * the capture library having to know about the destination.
+ *
+ * Contract:
+ *  - WriteAudio() may be called from a real-time media thread: be fast and
+ *    do your own locking; never block.
+ *  - 'data' is valid only for the duration of the call. Copy it to keep it.
+ *  - 'data' is raw PCM described by 'format' (sample format, channel count,
+ *    byte order, frame rate). The sink is responsible for any conversion it
+ *    needs (e.g. float -> int16).
+ */
+
+#ifndef AUDIO_SINK_H
+#define AUDIO_SINK_H
+
+#include <MediaDefs.h>
+#include <SupportDefs.h>
+
+class AudioSink {
+public:
+	virtual				~AudioSink() {}
+
+	virtual void		WriteAudio(const void* data, size_t size,
+							const media_raw_audio_format& format) = 0;
+};
+
+#endif // AUDIO_SINK_H

--- a/src/webcam/VideoConsumer.cpp
+++ b/src/webcam/VideoConsumer.cpp
@@ -50,14 +50,13 @@ const uint32 kFallbackHeight = 240;
 
 
 VideoConsumer::VideoConsumer(const char* name, BLooper* target,
-	uint32 frameMessage, uint32 audioMessage)
+	uint32 frameMessage)
 	:
 	BMediaNode(name),
 	BMediaEventLooper(),
 	BBufferConsumer(B_MEDIA_RAW_VIDEO),  // Prefer RAW_VIDEO but accept others in AcceptFormat
 	fTarget(target),
 	fFrameMessage(frameMessage),
-	fAudioMessage(audioMessage),
 	fConnected(false),
 	fBuffers(NULL),
 	fDisplayBitmap(NULL),

--- a/src/webcam/VideoConsumer.cpp
+++ b/src/webcam/VideoConsumer.cpp
@@ -9,7 +9,6 @@
  */
 
 #include "VideoConsumer.h"
-#include "MainWindow.h"
 
 #include <Autolock.h>
 #include <Buffer.h>

--- a/src/webcam/VideoConsumer.h
+++ b/src/webcam/VideoConsumer.h
@@ -32,7 +32,7 @@
 class VideoConsumer : public BMediaEventLooper, public BBufferConsumer {
 public:
 						VideoConsumer(const char* name, BLooper* target,
-							uint32 frameMessage, uint32 audioMessage);
+							uint32 frameMessage);
 	virtual				~VideoConsumer();
 
 	// BMediaNode interface
@@ -120,7 +120,6 @@ private:
 	BLooper*			fTarget;
 	mutable BLocker		fTargetLock;
 	uint32				fFrameMessage;
-	uint32				fAudioMessage;
 
 	media_input			fInput;
 	media_destination	fDestination;

--- a/src/webcam/WebcamDevice.cpp
+++ b/src/webcam/WebcamDevice.cpp
@@ -306,6 +306,32 @@ WebcamDevice::GetCurrentFrame() const
 }
 
 
+void
+WebcamDevice::SetAudioSink(AudioSink* sink)
+{
+	AudioConsumer* consumer = NULL;
+	{
+		BAutolock lock(fCaptureLock);
+		consumer = fAudioConsumer;
+	}
+	if (consumer != NULL)
+		consumer->SetAudioSink(sink);
+}
+
+
+void
+WebcamDevice::ClearAudioSink()
+{
+	AudioConsumer* consumer = NULL;
+	{
+		BAutolock lock(fCaptureLock);
+		consumer = fAudioConsumer;
+	}
+	if (consumer != NULL)
+		consumer->ClearAudioSink();
+}
+
+
 status_t
 WebcamDevice::GatherDeviceInfo()
 {
@@ -880,7 +906,7 @@ WebcamDevice::_SetupVideoConnection()
 
 	// Create video consumer
 	fVideoConsumer = new VideoConsumer("BubiCam Video", fTarget,
-		fFrameMessage, fAudioLevelMessage);
+		fFrameMessage);
 
 	// Register consumer
 	status = roster->RegisterNode(fVideoConsumer);

--- a/src/webcam/WebcamDevice.cpp
+++ b/src/webcam/WebcamDevice.cpp
@@ -7,7 +7,6 @@
 #include "WebcamDevice.h"
 #include "VideoConsumer.h"
 #include "AudioConsumer.h"
-#include "MainWindow.h"
 
 // Logging macros using centralized ErrorUtils
 #define LOG_MODULE "WebcamDevice"
@@ -178,6 +177,8 @@ WebcamDevice::WebcamDevice(const media_node& node, const dormant_node_info& info
 	fAudioProducerInstantiated(false),
 	fIsCapturing(false),
 	fTarget(NULL),
+	fFrameMessage(MSG_WEBCAM_FRAME),
+	fAudioLevelMessage(MSG_WEBCAM_AUDIO_LEVEL),
 	fUsedLiveNode(false),
 	fAudioNodeID(-1)
 {
@@ -211,6 +212,8 @@ WebcamDevice::WebcamDevice(const dormant_node_info& info, status_t instantiateEr
 	fAudioProducerInstantiated(false),
 	fIsCapturing(false),
 	fTarget(NULL),
+	fFrameMessage(MSG_WEBCAM_FRAME),
+	fAudioLevelMessage(MSG_WEBCAM_AUDIO_LEVEL),
 	fUsedLiveNode(false),
 	fAudioNodeID(-1)
 {
@@ -574,7 +577,8 @@ WebcamDevice::_GatherAudioInfo()
 
 
 status_t
-WebcamDevice::StartCapture(BLooper* target)
+WebcamDevice::StartCapture(BLooper* target, uint32 frameMessage,
+	uint32 audioLevelMessage)
 {
 	LOG_INFO("Starting capture for '%s'", fName.String());
 
@@ -586,6 +590,8 @@ WebcamDevice::StartCapture(BLooper* target)
 	}
 
 	fTarget = target;
+	fFrameMessage = frameMessage;
+	fAudioLevelMessage = audioLevelMessage;
 	fUsedLiveNode = false;
 
 	BMediaRoster* roster = BMediaRoster::Roster();
@@ -874,7 +880,7 @@ WebcamDevice::_SetupVideoConnection()
 
 	// Create video consumer
 	fVideoConsumer = new VideoConsumer("BubiCam Video", fTarget,
-		MSG_FRAME_RECEIVED, MSG_AUDIO_LEVEL);
+		fFrameMessage, fAudioLevelMessage);
 
 	// Register consumer
 	status = roster->RegisterNode(fVideoConsumer);
@@ -1365,7 +1371,7 @@ WebcamDevice::_SetupAudioConnection()
 
 	// Create audio consumer
 	fAudioConsumer = new AudioConsumer("BubiCam Audio", fTarget,
-		MSG_AUDIO_LEVEL);
+		fAudioLevelMessage);
 
 	// Register consumer
 	status = roster->RegisterNode(fAudioConsumer);

--- a/src/webcam/WebcamDevice.h
+++ b/src/webcam/WebcamDevice.h
@@ -22,6 +22,7 @@
 
 class VideoConsumer;
 class AudioConsumer;
+class AudioSink;
 
 // Default messages posted to the capture target looper.
 // They are owned by the capture library (not the application) so the
@@ -147,10 +148,14 @@ public:
 	void				SetAudioNodeID(int32 nodeID) { fAudioNodeID = nodeID; }
 	int32				AudioNodeID() const { return fAudioNodeID; }
 
+	// Route captured audio to a sink (recorder, encoder, ...). Safe to call
+	// before or during capture; ignored if there is no active audio consumer.
+	void				SetAudioSink(AudioSink* sink);
+	void				ClearAudioSink();
+
 	// Frame access (for MCP server)
 	BBitmap*			GetCurrentFrame() const;
 	VideoConsumer*		GetVideoConsumer() const { return fVideoConsumer; }
-	AudioConsumer*		GetAudioConsumer() const { return fAudioConsumer; }
 
 	// Capture statistics
 	uint32				FramesCaptured() const;

--- a/src/webcam/WebcamDevice.h
+++ b/src/webcam/WebcamDevice.h
@@ -23,6 +23,15 @@
 class VideoConsumer;
 class AudioConsumer;
 
+// Default messages posted to the capture target looper.
+// They are owned by the capture library (not the application) so the
+// component has no backward dependency on any app header. Override them
+// per-capture via StartCapture() to plug into your own message protocol.
+enum {
+	MSG_WEBCAM_FRAME		= 'frcv',
+	MSG_WEBCAM_AUDIO_LEVEL	= 'audl'
+};
+
 // Video format information
 struct VideoFormat {
 	int32		width;
@@ -124,8 +133,13 @@ public:
 	const dormant_node_info& DormantInfo() const { return fDormantInfo; }
 	void				MarkNodeReleased() { fNodeInstantiated = false; }
 
-	// Capture control
-	status_t			StartCapture(BLooper* target);
+	// Capture control.
+	// frameMessage / audioLevelMessage are the BMessage 'what' codes posted
+	// to 'target' for each video frame and audio level update. Defaults keep
+	// backward compatibility; override to integrate with a custom protocol.
+	status_t			StartCapture(BLooper* target,
+							uint32 frameMessage = MSG_WEBCAM_FRAME,
+							uint32 audioLevelMessage = MSG_WEBCAM_AUDIO_LEVEL);
 	void				StopCapture();
 	bool				IsCapturing() const { return fIsCapturing; }
 
@@ -214,6 +228,8 @@ private:
 	// Capture state
 	bool				fIsCapturing;
 	BLooper*			fTarget;
+	uint32				fFrameMessage;		// posted per video frame
+	uint32				fAudioLevelMessage;	// posted per audio level update
 	bool				fUsedLiveNode;	// True if we used an existing live node
 	int32				fAudioNodeID;	// -1=auto, 0=none, >0=specific node
 	mutable BLocker		fCaptureLock;	// Protects consumer pointers during capture/stop


### PR DESCRIPTION
Document the public contract of the src/webcam/ capture component so other
Haiku apps can reuse it: enumeration, push-based frame delivery via BLooper,
B_RGB32 frame format, threading/ownership rules, and build notes.